### PR TITLE
completed filterBB lock

### DIFF
--- a/src/locks/FilterBlackBoxLock.java
+++ b/src/locks/FilterBlackBoxLock.java
@@ -12,19 +12,19 @@ public class FilterBlackBoxLock implements ILock {
         this.gadgets = new GeneralizedPetersonLock[numProcesses];
 
         for (int i = 0; i < numProcesses; i++) {
-            gadgets[i] = new GeneralizedPetersonLock(numProcesses - i);
+            gadgets[i] = new GeneralizedPetersonLock(numProcesses);
         }
     }
 
-    public void acquireLock(int processId) {
+    public void acquireLock(int processId) { //subtract 1 from processId for each subsequent GPL so process num 4 doesn't try to acquire flag[4] of a GPL that only has flag of length 2
         for (int i = 0; i <= numProcesses - 1; i++) {
-            this.gadgets[i].acquireLock(processId - i > -1 ? processId - i : 0);
+            this.gadgets[i].acquireLock(processId);
         }
     }
 
     public void releaseLock(int processId) {
         for (int i = numProcesses - 1; i >= 0; i--) {
-            this.gadgets[i].releaseLock(processId - i > -1 ? processId - i : 0);
+            this.gadgets[i].releaseLock(processId);
         }
     }
 

--- a/src/locks/GeneralizedPetersonLock.java
+++ b/src/locks/GeneralizedPetersonLock.java
@@ -20,20 +20,20 @@ public class GeneralizedPetersonLock implements ILock {
         victim.set(me);
 
         //busy wait
-        boolean anyOtherFlagsTrue = false;
-        do {
-            for (int i = 0; i < flag.length; i++) {
-                if (i == me) continue;
-                if (flag[i].get()) {
-                    anyOtherFlagsTrue = true;
-                    break;
-                }
-            }
-        } while (anyOtherFlagsTrue && victim.get() == me);
+        while (hasConflict(me) && victim.get() == me);
     }
 
     @Override
     public void releaseLock(int me) {
         flag[me].set(false);
+    }
+
+    private boolean hasConflict(int me) {
+        for (int k = 0; k < flag.length; k++) {
+            if (k != me && flag[k].get()) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
used hasConflict function instead of checking if other process flag is true inside the while loop. made filterlock take n process GPL for EVERY rung instead of decreasing the number of processes in the GPL for each subsequent rung